### PR TITLE
Escape meta title HTML

### DIFF
--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -8,6 +8,7 @@ const prisma = require("../utils/prisma");
 const { v4 } = require("uuid");
 const { MetaGenerator } = require("../utils/boot/MetaGenerator");
 const { PGVector } = require("../utils/vectorDbProviders/pgvector");
+const { escapeHtml } = require("../utils/helpers/escapeHtml");
 
 function isNullOrNaN(value) {
   if (value === null) return true;
@@ -162,7 +163,7 @@ const SystemSettings = {
     meta_page_title: (newTitle) => {
       try {
         if (typeof newTitle !== "string" || !newTitle) return null;
-        return String(newTitle);
+        return escapeHtml(String(newTitle));
       } catch {
         return null;
       } finally {

--- a/server/tests/meta_page_title.test.js
+++ b/server/tests/meta_page_title.test.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const assert = require('assert');
+
+// stub SystemSettings before requiring MetaGenerator
+const stubPath = path.join(__dirname, '../models/systemSettings.js');
+require.cache[require.resolve(stubPath)] = {
+  id: stubPath,
+  filename: stubPath,
+  loaded: true,
+  exports: {
+    SystemSettings: {
+      async getValueOrFallback({ label }, fallback) {
+        if (label === 'meta_page_title') return '<script>alert("x")</script>';
+        if (label === 'meta_page_favicon') return null;
+        return fallback;
+      },
+    },
+  },
+};
+
+const { MetaGenerator } = require('../utils/boot/MetaGenerator');
+const { escapeHtml } = require('../utils/helpers/escapeHtml');
+
+(async () => {
+  const gen = new MetaGenerator();
+  const res = {
+    status() { return this; },
+    send(html) { this.html = html; return this; },
+  };
+  await gen.generate(res);
+  const expected = escapeHtml('<script>alert("x")</script>');
+  assert(res.html.includes(expected), 'Title was not escaped');
+  console.log('Test passed');
+})();

--- a/server/utils/boot/MetaGenerator.js
+++ b/server/utils/boot/MetaGenerator.js
@@ -5,6 +5,8 @@
  * @property {string|null} content - Text content to be injected between tags. If null self-closing.
  */
 
+const { escapeHtml } = require("../helpers/escapeHtml");
+
 /**
  * This class serves the default index.html page that is not present when built in production.
  * and therefore this class should not be called when in development mode since it is unused.
@@ -189,9 +191,10 @@ class MetaGenerator {
         {
           tag: "title",
           props: null,
-          content:
+          content: escapeHtml(
             customTitle ??
-            "AnythingLLM | Your personal LLM trained on anything",
+              "AnythingLLM | Your personal LLM trained on anything"
+          ),
         },
       ];
     }

--- a/server/utils/helpers/escapeHtml.js
+++ b/server/utils/helpers/escapeHtml.js
@@ -1,0 +1,8 @@
+function escapeHtml(str = "") {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+module.exports = { escapeHtml };


### PR DESCRIPTION
## Summary
- sanitize meta_page_title saving using `escapeHtml`
- embed sanitized meta title in MetaGenerator output
- provide helper escapeHtml utility
- add test verifying sanitized title rendering

## Testing
- `node server/tests/meta_page_title.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683f52615574832397dc4ae3317b04c2