### PR TITLE
Add auth endpoints and tests

### DIFF
--- a/server/endpoints/auth.js
+++ b/server/endpoints/auth.js
@@ -1,0 +1,39 @@
+const { reqBody } = require("../utils/http");
+const { AuthUser } = require("../models/authUser");
+
+function authEndpoints(app) {
+  if (!app) return;
+
+  app.post("/auth/register", async (request, response) => {
+    try {
+      const { email, password, role } = reqBody(request);
+      const { user, error } = await AuthUser.register({ email, password, role });
+      if (!user) {
+        response.status(400).json({ user: null, error });
+        return;
+      }
+      const { hashed_password, ...rest } = user;
+      response.status(200).json({ user: rest, error: null });
+    } catch (e) {
+      console.error(e);
+      response.sendStatus(500).end();
+    }
+  });
+
+  app.post("/auth/login", async (request, response) => {
+    try {
+      const { email, password } = reqBody(request);
+      const { token, user, error } = await AuthUser.authenticate(email, password);
+      if (!token) {
+        response.status(400).json({ token: null, error });
+        return;
+      }
+      response.status(200).json({ token });
+    } catch (e) {
+      console.error(e);
+      response.sendStatus(500).end();
+    }
+  });
+}
+
+module.exports = { authEndpoints };

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,7 @@ const { browserExtensionEndpoints } = require("./endpoints/browserExtension");
 const { communityHubEndpoints } = require("./endpoints/communityHub");
 const { agentFlowEndpoints } = require("./endpoints/agentFlows");
 const { mcpServersEndpoints } = require("./endpoints/mcpServers");
+const { authEndpoints } = require("./endpoints/auth");
 const app = express();
 const apiRouter = express.Router();
 const FILE_LIMIT = "3GB";
@@ -65,6 +66,7 @@ developerEndpoints(app, apiRouter);
 communityHubEndpoints(apiRouter);
 agentFlowEndpoints(apiRouter);
 mcpServersEndpoints(apiRouter);
+authEndpoints(apiRouter);
 
 // Externally facing embedder endpoints
 embeddedEndpoints(apiRouter);

--- a/server/models/authUser.js
+++ b/server/models/authUser.js
@@ -1,0 +1,34 @@
+const prisma = require("../utils/prisma");
+const bcrypt = require("bcrypt");
+const { makeJWT } = require("../utils/http");
+
+const AuthUser = {
+  async register({ email, password, role = "user" }) {
+    try {
+      const hashed = await bcrypt.hash(password, 10);
+      const user = await prisma.user.create({
+        data: { email, hashed_password: hashed, role },
+      });
+      return { user, error: null };
+    } catch (error) {
+      console.error(error.message);
+      return { user: null, error: error.message };
+    }
+  },
+
+  async authenticate(email, password) {
+    try {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) return { token: null, user: null, error: "Invalid credentials." };
+      const match = await bcrypt.compare(password, user.hashed_password);
+      if (!match) return { token: null, user: null, error: "Invalid credentials." };
+      const token = makeJWT({ id: user.id, email: user.email, role: user.role });
+      return { token, user, error: null };
+    } catch (error) {
+      console.error(error.message);
+      return { token: null, user: null, error: error.message };
+    }
+  },
+};
+
+module.exports = { AuthUser };

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -355,3 +355,12 @@ model prompt_history {
 
   @@index([workspaceId])
 }
+
+model User {
+  id             Int      @id @default(autoincrement())
+  email          String   @unique
+  hashed_password String
+  role           String   @default("user")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+}

--- a/server/tests/auth_register_login.test.js
+++ b/server/tests/auth_register_login.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const path = require('path');
+const bcrypt = require('bcrypt');
+
+const prismaStub = {
+  user: {
+    async create({ data }) {
+      prismaStub.created = data;
+      return { id: 1, ...data };
+    },
+    async findUnique({ where }) {
+      if (prismaStub.created && prismaStub.created.email === where.email) {
+        return { id: 1, ...prismaStub.created };
+      }
+      return null;
+    },
+  },
+};
+
+const prismaPath = path.join(__dirname, '../utils/prisma');
+require.cache[require.resolve(prismaPath)] = {
+  id: prismaPath,
+  filename: prismaPath,
+  loaded: true,
+  exports: prismaStub,
+};
+
+process.env.JWT_SECRET = 'secret';
+const { AuthUser } = require('../models/authUser');
+
+(async () => {
+  const { user } = await AuthUser.register({ email: 'a@test.com', password: 'pw' });
+  assert(user && user.id === 1, 'User not created');
+  assert.notStrictEqual(prismaStub.created.hashed_password, 'pw');
+  const ok = await bcrypt.compare('pw', prismaStub.created.hashed_password);
+  assert.ok(ok, 'Password not hashed');
+
+  const { token } = await AuthUser.authenticate('a@test.com', 'pw');
+  assert.ok(token, 'Token not returned');
+  console.log('Test passed');
+})();


### PR DESCRIPTION
## Summary
- create new `User` model in Prisma schema
- add AuthUser model for registration/authentication
- implement `/auth/register` and `/auth/login` endpoints
- wire up auth routes in server index
- provide test for password hashing and token issuance

## Testing
- `yarn --cwd server node tests/auth_register_login.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683f6b91a13c832380de970ec0739298