### PR TITLE
Add plan management and default user plan

### DIFF
--- a/server/endpoints/plans.js
+++ b/server/endpoints/plans.js
@@ -1,0 +1,91 @@
+const { Plan } = require("../models/plan");
+const { UserPlan } = require("../models/userPlan");
+const { reqBody, userFromSession } = require("../utils/http");
+const { validatedRequest } = require("../utils/middleware/validatedRequest");
+const { strictMultiUserRoleValid, ROLES } = require("../utils/middleware/multiUserProtected");
+
+function planEndpoints(app) {
+  if (!app) return;
+
+  app.get("/plans", async (_req, res) => {
+    try {
+      const plans = await Plan.where();
+      res.status(200).json({ plans });
+    } catch (e) {
+      console.error(e);
+      res.sendStatus(500).end();
+    }
+  });
+
+  app.post(
+    "/plans",
+    [validatedRequest, strictMultiUserRoleValid([ROLES.admin])],
+    async (req, res) => {
+      try {
+        const inputs = reqBody(req);
+        const { plan, error } = await Plan.create(inputs);
+        if (!plan) {
+          res.status(400).json({ plan: null, error });
+          return;
+        }
+        res.status(200).json({ plan, error: null });
+      } catch (e) {
+        console.error(e);
+        res.sendStatus(500).end();
+      }
+    }
+  );
+
+  app.put(
+    "/plans/:id",
+    [validatedRequest, strictMultiUserRoleValid([ROLES.admin])],
+    async (req, res) => {
+      try {
+        const { id } = req.params;
+        const updates = reqBody(req);
+        const { plan, error } = await Plan.update(id, updates);
+        if (!plan) {
+          res.status(400).json({ plan: null, error });
+          return;
+        }
+        res.status(200).json({ plan, error: null });
+      } catch (e) {
+        console.error(e);
+        res.sendStatus(500).end();
+      }
+    }
+  );
+
+  app.delete(
+    "/plans/:id",
+    [validatedRequest, strictMultiUserRoleValid([ROLES.admin])],
+    async (req, res) => {
+      try {
+        const { id } = req.params;
+        const success = await Plan.delete(id);
+        res.status(200).json({ success });
+      } catch (e) {
+        console.error(e);
+        res.sendStatus(500).end();
+      }
+    }
+  );
+
+  app.post("/plans/change/:id", [validatedRequest], async (req, res) => {
+    try {
+      const { id } = req.params;
+      const user = await userFromSession(req, res);
+      const { userPlan, error } = await UserPlan.assign(user.id, id);
+      if (!userPlan) {
+        res.status(400).json({ success: false, error });
+        return;
+      }
+      res.status(200).json({ success: true, error: null });
+    } catch (e) {
+      console.error(e);
+      res.sendStatus(500).end();
+    }
+  });
+}
+
+module.exports = { planEndpoints };

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,7 @@ const { communityHubEndpoints } = require("./endpoints/communityHub");
 const { agentFlowEndpoints } = require("./endpoints/agentFlows");
 const { mcpServersEndpoints } = require("./endpoints/mcpServers");
 const { authEndpoints } = require("./endpoints/auth");
+const { planEndpoints } = require("./endpoints/plans");
 const app = express();
 const apiRouter = express.Router();
 const FILE_LIMIT = "3GB";
@@ -64,9 +65,10 @@ agentWebsocket(apiRouter);
 experimentalEndpoints(apiRouter);
 developerEndpoints(app, apiRouter);
 communityHubEndpoints(apiRouter);
-agentFlowEndpoints(apiRouter);
-mcpServersEndpoints(apiRouter);
-authEndpoints(apiRouter);
+  agentFlowEndpoints(apiRouter);
+  mcpServersEndpoints(apiRouter);
+  authEndpoints(apiRouter);
+  planEndpoints(apiRouter);
 
 // Externally facing embedder endpoints
 embeddedEndpoints(apiRouter);

--- a/server/models/authUser.js
+++ b/server/models/authUser.js
@@ -1,6 +1,8 @@
 const prisma = require("../utils/prisma");
 const bcrypt = require("bcrypt");
 const { makeJWT } = require("../utils/http");
+const { Plan } = require("./plan");
+const { UserPlan } = require("./userPlan");
 
 const AuthUser = {
   async register({ email, password, role = "user" }) {
@@ -9,6 +11,11 @@ const AuthUser = {
       const user = await prisma.user.create({
         data: { email, hashed_password: hashed, role },
       });
+      let plan = await Plan.get({ name: "Free" });
+      if (!plan) {
+        ({ plan } = await Plan.create({ name: "Free" }));
+      }
+      if (plan) await UserPlan.assign(user.id, plan.id);
       return { user, error: null };
     } catch (error) {
       console.error(error.message);

--- a/server/models/plan.js
+++ b/server/models/plan.js
@@ -1,0 +1,55 @@
+const prisma = require("../utils/prisma");
+
+const Plan = {
+  create: async function (inputs = {}) {
+    try {
+      const plan = await prisma.plans.create({ data: inputs });
+      return { plan, error: null };
+    } catch (error) {
+      console.error(error.message);
+      return { plan: null, error: error.message };
+    }
+  },
+
+  update: async function (id = null, updates = {}) {
+    try {
+      const plan = await prisma.plans.update({ where: { id: Number(id) }, data: updates });
+      return { plan, error: null };
+    } catch (error) {
+      console.error(error.message);
+      return { plan: null, error: error.message };
+    }
+  },
+
+  delete: async function (id = null) {
+    try {
+      await prisma.plans.delete({ where: { id: Number(id) } });
+      return true;
+    } catch (error) {
+      console.error(error.message);
+      return false;
+    }
+  },
+
+  get: async function (clause = {}) {
+    try {
+      const plan = await prisma.plans.findFirst({ where: clause });
+      return plan || null;
+    } catch (error) {
+      console.error(error.message);
+      return null;
+    }
+  },
+
+  where: async function (clause = {}) {
+    try {
+      const plans = await prisma.plans.findMany({ where: clause });
+      return plans;
+    } catch (error) {
+      console.error(error.message);
+      return [];
+    }
+  },
+};
+
+module.exports = { Plan };

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -110,6 +110,17 @@ const User = {
             this.validations.dailyMessageLimit(dailyMessageLimit),
         },
       });
+      try {
+        const { Plan } = require("./plan");
+        const { UserPlan } = require("./userPlan");
+        let plan = await Plan.get({ name: "Free" });
+        if (!plan) {
+          ({ plan } = await Plan.create({ name: "Free" }));
+        }
+        if (plan) await UserPlan.assign(user.id, plan.id);
+      } catch (e) {
+        console.error(e.message);
+      }
       return { user: this.filterFields(user), error: null };
     } catch (error) {
       console.error("FAILED TO CREATE USER.", error.message);

--- a/server/models/userPlan.js
+++ b/server/models/userPlan.js
@@ -1,0 +1,32 @@
+const prisma = require("../utils/prisma");
+
+const UserPlan = {
+  assign: async function (userId, planId) {
+    try {
+      const userPlan = await prisma.user_plans.upsert({
+        where: { userId: Number(userId) },
+        update: { planId: Number(planId) },
+        create: { userId: Number(userId), planId: Number(planId) },
+      });
+      return { userPlan, error: null };
+    } catch (error) {
+      console.error(error.message);
+      return { userPlan: null, error: error.message };
+    }
+  },
+
+  get: async function (userId) {
+    try {
+      const userPlan = await prisma.user_plans.findUnique({
+        where: { userId: Number(userId) },
+        include: { plan: true },
+      });
+      return userPlan || null;
+    } catch (error) {
+      console.error(error.message);
+      return null;
+    }
+  },
+};
+
+module.exports = { UserPlan };

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -364,3 +364,24 @@ model User {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 }
+
+model plans {
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  price       Int?
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  user_plans  user_plans[]
+}
+
+model user_plans {
+  id        Int    @id @default(autoincrement())
+  userId    Int    @unique
+  planId    Int
+  assignedAt DateTime @default(now())
+  user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  plan      plans  @relation(fields: [planId], references: [id], onDelete: Cascade)
+
+  @@index([planId])
+}

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -19,6 +19,11 @@ async function main() {
       });
     }
   }
+
+  const planExists = await prisma.plans.findFirst({ where: { name: "Free" } });
+  if (!planExists) {
+    await prisma.plans.create({ data: { name: "Free", price: 0 } });
+  }
 }
 
 main()

--- a/server/tests/plans_create.test.js
+++ b/server/tests/plans_create.test.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const assert = require('assert');
+
+const prismaStub = {
+  plans: {
+    async create({ data }) {
+      prismaStub.created = data;
+      return { id: 1, ...data };
+    },
+  },
+};
+
+const prismaPath = path.join(__dirname, '../utils/prisma');
+require.cache[require.resolve(prismaPath)] = {
+  id: prismaPath,
+  filename: prismaPath,
+  loaded: true,
+  exports: prismaStub,
+};
+
+const { Plan } = require('../models/plan');
+
+(async () => {
+  const { plan } = await Plan.create({ name: 'Pro', price: 10 });
+  assert.deepStrictEqual(prismaStub.created, { name: 'Pro', price: 10 });
+  assert(plan && plan.id === 1, 'Plan not returned');
+  console.log('Test passed');
+})();

--- a/server/tests/user_plan_link.test.js
+++ b/server/tests/user_plan_link.test.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const assert = require('assert');
+const bcrypt = require('bcrypt');
+
+const prismaStub = {
+  user: {
+    async create({ data }) {
+      prismaStub.userCreated = data;
+      return { id: 1, ...data };
+    },
+  },
+  plans: {
+    async findFirst({ where }) {
+      if (where.name === 'Free') return { id: 2, name: 'Free' };
+      return null;
+    },
+    async create({ data }) {
+      prismaStub.planCreated = data;
+      return { id: 2, ...data };
+    },
+  },
+  user_plans: {
+    async upsert(args) {
+      prismaStub.upsertArgs = args;
+      return { id: 3 };
+    },
+  },
+};
+
+const prismaPath = path.join(__dirname, '../utils/prisma');
+require.cache[require.resolve(prismaPath)] = {
+  id: prismaPath,
+  filename: prismaPath,
+  loaded: true,
+  exports: prismaStub,
+};
+
+const { AuthUser } = require('../models/authUser');
+
+(async () => {
+  await AuthUser.register({ email: 'a@test.com', password: 'pw' });
+  assert.ok(prismaStub.upsertArgs, 'Plan not assigned');
+  assert.strictEqual(prismaStub.upsertArgs.create.planId, 2);
+  const ok = await bcrypt.compare('pw', prismaStub.userCreated.hashed_password);
+  assert.ok(ok, 'Password not hashed');
+  console.log('Test passed');
+})();


### PR DESCRIPTION
## Summary
- add Plan and UserPlan models to Prisma schema
- seed default `Free` plan
- implement model helpers for plans
- add CRUD endpoints for plans with role checks
- link new users to default plan
- expose plan management routes in server index
- provide tests for plan creation and user plan linkage

## Testing
- `node --require ./server/.pnp.cjs server/tests/plans_create.test.js`
- `node --require ./server/.pnp.cjs server/tests/user_plan_link.test.js`


------
https://chatgpt.com/codex/tasks/task_e_683f6d43208c83239eac8297b7d80ed9