### PR TITLE
Add basic auth pages and plan manager component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,8 @@ import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import Login from "@/pages/Login";
 import SimpleSSOPassthrough from "@/pages/Login/SSO/simple";
+const AuthLogin = lazy(() => import("@/pages/auth/login"));
+const AuthRegister = lazy(() => import("@/pages/auth/register"));
 import OnboardingFlow from "@/pages/OnboardingFlow";
 import i18n from "./i18n";
 
@@ -101,6 +103,8 @@ export default function App() {
                 <Routes>
                   <Route path="/" element={<PrivateRoute Component={Main} />} />
                   <Route path="/login" element={<Login />} />
+                  <Route path="/auth/login" element={<AuthLogin />} />
+                  <Route path="/auth/register" element={<AuthRegister />} />
                   <Route
                     path="/sso/simple"
                     element={<SimpleSSOPassthrough />}

--- a/frontend/src/components/PlanManager.tsx
+++ b/frontend/src/components/PlanManager.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+import Plan from "@/models/plan";
+import showToast from "@/utils/toast";
+
+interface PlanType {
+  id: number;
+  name: string;
+  price?: number;
+  description?: string;
+}
+
+export default function PlanManager() {
+  const [plans, setPlans] = useState<PlanType[]>([]);
+
+  useEffect(() => {
+    async function fetchPlans() {
+      const results = await Plan.all();
+      setPlans(results);
+    }
+    fetchPlans();
+  }, []);
+
+  const handleUpgrade = async (id: number) => {
+    const { success, error } = await Plan.change(id);
+    if (success) {
+      showToast("Plan updated", "success");
+    } else {
+      showToast(error || "Failed to update plan", "error");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {plans.map((p) => (
+        <div
+          key={p.id}
+          className="border p-4 rounded flex items-center justify-between"
+        >
+          <div>
+            <div className="font-bold">{p.name}</div>
+            {p.description && (
+              <div className="text-sm opacity-80">{p.description}</div>
+            )}
+            {typeof p.price === "number" && (
+              <div className="text-sm">${p.price}</div>
+            )}
+          </div>
+          <button
+            onClick={() => handleUpgrade(p.id)}
+            className="bg-green-500 text-white px-3 py-1 rounded"
+          >
+            Upgrade
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/models/plan.js
+++ b/frontend/src/models/plan.js
@@ -1,0 +1,24 @@
+import { API_BASE } from "@/utils/constants";
+import { baseHeaders } from "@/utils/request";
+
+const Plan = {
+  all: async () => {
+    return fetch(`${API_BASE}/plans`, {
+      method: "GET",
+      headers: baseHeaders(),
+    })
+      .then((res) => res.json())
+      .then((res) => res.plans || [])
+      .catch(() => []);
+  },
+  change: async (planId) => {
+    return fetch(`${API_BASE}/plans/change/${planId}`, {
+      method: "POST",
+      headers: baseHeaders(),
+    })
+      .then((res) => res.json())
+      .catch((e) => ({ success: false, error: e.message }));
+  },
+};
+
+export default Plan;

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useContext } from "react";
+import { AuthContext } from "@/AuthContext";
+import { API_BASE } from "@/utils/constants";
+import { useNavigate } from "react-router-dom";
+import showToast from "@/utils/toast";
+
+export default function AuthLogin() {
+  const { actions } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const res = await fetch(`${API_BASE}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    })
+      .then((r) => r.json())
+      .catch(() => ({ token: null }));
+    setLoading(false);
+    if (res?.token) {
+      actions.updateUser({ email }, res.token);
+      navigate("/");
+    } else {
+      showToast("Login failed", "error");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        placeholder="Email"
+        className="border p-2 rounded"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+        placeholder="Password"
+        className="border p-2 rounded"
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className="bg-blue-500 text-white rounded p-2"
+      >
+        {loading ? "Logging in..." : "Login"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import { API_BASE } from "@/utils/constants";
+import { useNavigate } from "react-router-dom";
+import showToast from "@/utils/toast";
+
+export default function AuthRegister() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const res = await fetch(`${API_BASE}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    })
+      .then((r) => r.json())
+      .catch(() => ({ user: null }));
+    setLoading(false);
+    if (res?.user) {
+      showToast("Registration successful", "success");
+      navigate("/auth/login");
+    } else {
+      showToast(res?.error || "Registration failed", "error");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        placeholder="Email"
+        className="border p-2 rounded"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+        placeholder="Password"
+        className="border p-2 rounded"
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className="bg-blue-500 text-white rounded p-2"
+      >
+        {loading ? "Registering..." : "Register"}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce login/register pages under `src/pages/auth`
- provide plan API model and `PlanManager` component
- wire new routes in `App.jsx`

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_683f6fe5fbd88323977e36d67003bcf0