### PR TITLE
Implement JWT auth middleware

### DIFF
--- a/server/endpoints/plans.js
+++ b/server/endpoints/plans.js
@@ -1,8 +1,7 @@
 const { Plan } = require("../models/plan");
 const { UserPlan } = require("../models/userPlan");
 const { reqBody, userFromSession } = require("../utils/http");
-const { validatedRequest } = require("../utils/middleware/validatedRequest");
-const { strictMultiUserRoleValid, ROLES } = require("../utils/middleware/multiUserProtected");
+const { auth, requireRole } = require("../middleware/auth");
 
 function planEndpoints(app) {
   if (!app) return;
@@ -19,7 +18,7 @@ function planEndpoints(app) {
 
   app.post(
     "/plans",
-    [validatedRequest, strictMultiUserRoleValid([ROLES.admin])],
+    [auth, requireRole("admin")],
     async (req, res) => {
       try {
         const inputs = reqBody(req);
@@ -38,7 +37,7 @@ function planEndpoints(app) {
 
   app.put(
     "/plans/:id",
-    [validatedRequest, strictMultiUserRoleValid([ROLES.admin])],
+    [auth, requireRole("admin")],
     async (req, res) => {
       try {
         const { id } = req.params;
@@ -58,7 +57,7 @@ function planEndpoints(app) {
 
   app.delete(
     "/plans/:id",
-    [validatedRequest, strictMultiUserRoleValid([ROLES.admin])],
+    [auth, requireRole("admin")],
     async (req, res) => {
       try {
         const { id } = req.params;
@@ -71,7 +70,7 @@ function planEndpoints(app) {
     }
   );
 
-  app.post("/plans/change/:id", [validatedRequest], async (req, res) => {
+  app.post("/plans/change/:id", [auth], async (req, res) => {
     try {
       const { id } = req.params;
       const user = await userFromSession(req, res);

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -35,6 +35,7 @@ const { WorkspaceThread } = require("../models/workspaceThread");
 const truncate = require("truncate");
 const { purgeDocument } = require("../utils/files/purgeDocument");
 const { getModelTag } = require("./utils");
+const { auth } = require("../middleware/auth");
 
 function workspaceEndpoints(app) {
   if (!app) return;
@@ -113,6 +114,7 @@ function workspaceEndpoints(app) {
   app.post(
     "/workspace/:slug/upload",
     [
+      auth,
       validatedRequest,
       flexUserRoleValid([ROLES.admin, ROLES.manager]),
       handleFileUpload,
@@ -162,7 +164,7 @@ function workspaceEndpoints(app) {
 
   app.post(
     "/workspace/:slug/upload-link",
-    [validatedRequest, flexUserRoleValid([ROLES.admin, ROLES.manager])],
+    [auth, validatedRequest, flexUserRoleValid([ROLES.admin, ROLES.manager])],
     async (request, response) => {
       try {
         const Collector = new CollectorApi();
@@ -370,7 +372,7 @@ function workspaceEndpoints(app) {
 
   app.get(
     "/workspace/:slug/chats",
-    [validatedRequest, flexUserRoleValid([ROLES.all])],
+    [auth, validatedRequest, flexUserRoleValid([ROLES.all])],
     async (request, response) => {
       try {
         const { slug } = request.params;

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,35 @@
+const { decodeJWT } = require("../utils/http");
+const { User } = require("../models/user");
+
+async function auth(req, res, next) {
+  const authHeader = req.header("Authorization");
+  const token = authHeader ? authHeader.split(" ")[1] : null;
+  if (!token) {
+    res.status(401).json({ error: "No auth token found." });
+    return;
+  }
+  const payload = decodeJWT(token);
+  if (!payload || !payload.id) {
+    res.status(401).json({ error: "Invalid auth token." });
+    return;
+  }
+  const user = await User.get({ id: payload.id });
+  if (!user) {
+    res.status(401).json({ error: "Invalid auth user." });
+    return;
+  }
+  req.user = user;
+  next();
+}
+
+function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.user || req.user.role !== role) {
+      res.status(403).json({ error: "Forbidden" });
+      return;
+    }
+    next();
+  };
+}
+
+module.exports = { auth, requireRole };

--- a/server/tests/auth_middleware.test.js
+++ b/server/tests/auth_middleware.test.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+const path = require('path');
+
+process.env.JWT_SECRET = 'secret';
+
+const httpPath = path.join(__dirname, '../utils/http');
+require.cache[require.resolve(httpPath)] = {
+  id: httpPath,
+  filename: httpPath,
+  loaded: true,
+  exports: { decodeJWT: () => ({ id: 1 }) },
+};
+
+const userPath = path.join(__dirname, '../models/user');
+let getCalled = false;
+require.cache[require.resolve(userPath)] = {
+  id: userPath,
+  filename: userPath,
+  loaded: true,
+  exports: { User: { get: async () => { getCalled = true; return { id: 1, role: 'admin' }; } } },
+};
+
+const { auth, requireRole } = require('../middleware/auth');
+
+(async () => {
+  const req = { header: () => null };
+  let status;
+  const res = { status(s){ status = s; return { json(){ } }; } };
+  let nextCalled = false;
+  await auth(req, res, () => { nextCalled = true; });
+  assert.strictEqual(status, 401);
+  assert.strictEqual(nextCalled, false);
+
+  req.header = () => 'Bearer token';
+  status = undefined; nextCalled = false; getCalled = false;
+  await auth(req, res, () => { nextCalled = true; });
+  assert.strictEqual(status, undefined);
+  assert.ok(nextCalled);
+  assert.ok(getCalled);
+  assert.deepStrictEqual(req.user, { id: 1, role: 'admin' });
+
+  nextCalled = false; status = undefined;
+  await requireRole('admin')(req, res, () => { nextCalled = true; });
+  assert.ok(nextCalled);
+
+  req.user.role = 'user';
+  nextCalled = false;
+  await requireRole('admin')(req, res, () => { nextCalled = true; });
+  assert.strictEqual(status, 403);
+  assert.strictEqual(nextCalled, false);
+  console.log('Test passed');
+})();


### PR DESCRIPTION
## Summary
- create `auth` middleware for JWT validation and role checks
- secure document upload and chat history routes with auth
- restrict plan management endpoints to admin role
- cover auth middleware with unit tests

## Testing
- `node server/tests/auth_middleware.test.js`
- `node server/tests/plans_create.test.js`


------
https://chatgpt.com/codex/tasks/task_e_683f746965888323a3511b397f69c25e